### PR TITLE
Extends definable :with parameters for acts_as_sanitizable

### DIFF
--- a/lib/acts_as_sanitizable.rb
+++ b/lib/acts_as_sanitizable.rb
@@ -10,26 +10,28 @@ module ActsAsSanitizable
   # === Example:
   #   class User < ActiveRecord::Base   
   #     sanitizes :content, with: :squish
+  #     sanitizes :content, :another_attribute, :nth_attribute, with: [:strip, :upcase]
   #     sanitizes :content do |content|
   #       content.squish.downcase
   #     end
+  #     sanitizes :content, with: ->(content) { content.squish.downcase }
   #   end
   def sanitizes(*attribute_names, &block)
-    options = attribute_names.extract_options!
-    options.assert_valid_keys(:with)
-    options.reverse_merge!(with: block_given? ? block : :strip)
-    if sanitizer = options[:with]      
-      unless sanitizer.respond_to?(:call) 
-        sanitizer_name = sanitizer # this is necessary cuz of some strange behaviour
-        sanitizer = -> (value) {           
-          Array(sanitizer_name).inject(value) { |prev_value, method| prev_value.send(method) } 
-        }        
-      end
+    options = attribute_names.extract_options!.assert_valid_keys(:with, :on).reverse_merge(with: block_given? ? block : :strip)
+ 
+    attribute_sanitizers = Array(options[:with]).map(&:to_proc)
+    
+    if attribute_sanitizers.any?
       before_validation options.slice(:on) do
-       attribute_names.each do |attribute_name|
-         attribute_value = send(attribute_name)
-         send("#{attribute_name}=", sanitizer.call(attribute_value)) unless attribute_value.nil?
-       end
+        attribute_names.each do |attribute_name|
+          attribute_value = self.send(attribute_name)
+          unless attribute_value.nil?
+            sanitized_value = attribute_sanitizers.inject(attribute_value) do |prev_value, sanitizer_proc|
+              sanitizer_proc.call(prev_value)
+            end
+            self.send("#{attribute_name}=", sanitized_value) 
+          end
+        end
       end
     end
   end

--- a/spec/models/acts_as_sanitizable_spec.rb
+++ b/spec/models/acts_as_sanitizable_spec.rb
@@ -19,8 +19,9 @@ describe ActsAsSanitizable do
     expect(user.email).to eq("christoph@chilian.de")
   end
 
-
-
-
+  it "username should be downcased gsub'ed" do
+    user = create(:user, username: '@YamYam')
+    expect(user.username).to eq 'yamyam'
+  end
 
 end

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -1,5 +1,6 @@
 class User < ActiveRecord::Base
 
+  sanitizes :username, with: [:downcase, ->(content) { content.gsub(/\A@/, '') }]
   sanitizes :first_name, with: :strip
   sanitizes :last_name, with: :upcase
 


### PR DESCRIPTION
Extends acts_as_sanitizable to accept Symbols, Procs and Array of Procs or Symbols as :with parameter
